### PR TITLE
Add complete comment RE why the Pixel struct has a < operator

### DIFF
--- a/BitmapToShaderExpression/ReadFile.h
+++ b/BitmapToShaderExpression/ReadFile.h
@@ -11,7 +11,7 @@ struct Pixel {
 	float r, g, b;
 	const int pixelConverter = 255;
 
-	// Have to define comparison op so that 
+	// Have to define comparison op so that pixels can be sorted in map
 	bool operator < (const Pixel other) const {
 		return r < other.r && g < other.g && b < other.b;
 	}


### PR DESCRIPTION
Pixel struct needs to have "<" operator defined so that std::map can hold Pixel-int pairs