### PR TITLE
Fix csv firstline

### DIFF
--- a/BitmapToShaderExpression/BitmapToShaderExpression.vcxproj
+++ b/BitmapToShaderExpression/BitmapToShaderExpression.vcxproj
@@ -173,6 +173,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="GXvmX.csv" />
+    <None Include="GXvmX_64_64.csv" />
     <None Include="GXvmX_orig.csv" />
     <None Include="HTMLPage.htm">
       <DeploymentContent>true</DeploymentContent>

--- a/BitmapToShaderExpression/BitmapToShaderExpression.vcxproj.filters
+++ b/BitmapToShaderExpression/BitmapToShaderExpression.vcxproj.filters
@@ -64,6 +64,9 @@
     <None Include="GXvmX_orig.csv">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="GXvmX_64_64.csv">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="BitmapToShaderExpression.rc">

--- a/BitmapToShaderExpression/ReadFile.cpp
+++ b/BitmapToShaderExpression/ReadFile.cpp
@@ -21,6 +21,11 @@ std::map<std::pair<int, int>, Pixel> ReadFile::TextToPixelTable(const::std::stri
 	std::istringstream iss(data);
 	std::string line;
 
+	int xmax, ymax, zmax;
+	std::string firstLine;
+	getline(iss, firstLine);
+	sscanf_s(firstLine.c_str(), "%d, %d, %d", &xmax, &ymax, &zmax);
+	
 	while (getline(iss, line)) {
 		int x, y, r, g, b;
 


### PR DESCRIPTION
Fix issues where actual CSV was not in MSVC resources, and where first line of CSV was being parsed as any other line in CSV. It is a different format <int, int, int>

Fixes #9 