### PR TITLE
Fix containment comparison

### DIFF
--- a/BitmapToShaderExpression/PixelMapModel.cpp
+++ b/BitmapToShaderExpression/PixelMapModel.cpp
@@ -41,8 +41,8 @@ PixelMapModel::~PixelMapModel()
 
 bool PixelMapModel::Contains(std::pair<int, int> ijCoord)
 {
-	if (ijCoord.first >= minx && ijCoord.first <= maxx &&
-		ijCoord.second >= miny && ijCoord.second <= maxy)
+	if (ijCoord.first >= minx && ijCoord.first < maxx &&
+		ijCoord.second >= miny && ijCoord.second < maxy)
 		return true;
 
 	for (PixelMapModel elem : subModels) {


### PR DESCRIPTION
Do not check if upper bound matches.
This was introducing a false positive where e.g. trying to check containment in cell (24,24) would give positive result for a pixel which spanned from (23,23) to (24,24) would return pixel 23,23

Closes #11 