### PR TITLE
Fix pixel set, operator<

### DIFF
--- a/BitmapToShaderExpression/ReadFile.h
+++ b/BitmapToShaderExpression/ReadFile.h
@@ -12,7 +12,7 @@ struct Pixel {
 	const int pixelConverter = 255;
 
 	// Have to define comparison op so that pixels can be sorted in map
-	bool operator < (const Pixel other) const {
+	bool operator < (const Pixel& other) const {
 		return r < other.r && g < other.g && b < other.b;
 	}
 

--- a/BitmapToShaderExpression/ReadFile.h
+++ b/BitmapToShaderExpression/ReadFile.h
@@ -13,7 +13,9 @@ struct Pixel {
 
 	// Have to define comparison op so that pixels can be sorted in map
 	bool operator < (const Pixel& other) const {
-		return r < other.r && g < other.g && b < other.b;
+		return r < other.r ||
+			r == other.r && g < other.g ||
+			r == other.r && g == other.g && b < other.b;
 	}
 
 	operator std::string() {


### PR DESCRIPTION
Fix an issue with our implementation of operator< where many pixels would be treated as equivalent to each other.

In general, for sets to work on multidimensional data types, we need a comparison like
dim0 < other.dim0 OR
dim0 == other.dim0 AND dim1 < other.dim1 OR
dim0 == other.dim0 AND dim1 == other.dim1 AND dim2 < other.dim2...

Etc.

Fixes #14 