### PR TITLE
Fix: tabbed strings for submodels

### DIFF
--- a/BitmapToShaderExpression/PixelMapModel.cpp
+++ b/BitmapToShaderExpression/PixelMapModel.cpp
@@ -100,9 +100,17 @@ PixelMapModel::operator std::string() {
 		stringStream << getPixelSpan();
 	}
 	else {
+		stringStream << getPixelSpan() << std::endl;
+
 		// case: have submodels. each submodel is a new line, tabbed in
 		for (PixelMapModel elem : subModels) {
-			stringStream << "\t" << (std::string) elem << std::endl;
+			std::stringstream ssElem((std::string) elem);
+			std::string holder;
+			// split the child's string content on newline
+			while (std::getline(ssElem, holder, '\n')) {
+				// shift all of the child steams over by 1 tab
+				stringStream << "\t" << holder << std::endl;
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolve an issue where string content would be misformatted. 

Gives results like

    whole map
    0 < x <  64,   0 < y <  64: pixel r0 g0 b0
          0 < x <  31,   0 < y <  31: pixel r0 g0 b0
                  0 < x <  15,   0 < y <  15: pixel r255 g255 b255
                  0 < x <  15,  15 < y <  31: pixel r255 g255 b255
                 15 < x <  31,   0 < y <  15: pixel r0 g0 b0
                         15 < x <  22,   0 < y <   7: pixel r255 g255 b255
                         15 < x <  22,   7 < y <  15: pixel r255 g255 b255
                         22 < x <  31,   0 < y <   7: pixel r255 g255 b255
                         22 < x <  31,   7 < y <  15: pixel r0 g0 b0
                                 22 < x <  26,   7 < y <  10: pixel r255 g255 b255
                                 22 < x <  26,  10 < y <  15: pixel r0 g0 b0
                                         22 < x <  23,  10 < y <  12: pixel r255 g255 b255
                                         22 < x <  23,  12 < y <  15: pixel r0 g0 b0
                                                 22 < x <  23,  12 < y <  13: pixel r255 g255 b255
                                                 22 < x <  23,  13 < y <  14: pixel r255 g255 b255
                                                 22 < x <  23,  14 < y <  15: pixel r96 g144 b152