### PR TITLE
Feature: int32 backer

### DIFF
--- a/PixelBits/Pixel64.h
+++ b/PixelBits/Pixel64.h
@@ -7,13 +7,21 @@
 struct Pixel64
 {
 public:
-	unsigned short r;
-	unsigned short g;
-	unsigned short b;
-	unsigned short a;
+	unsigned int backer;
+
+	Pixel64(unsigned int bits) {
+		// assume that backer is an int32_t
+		backer = bits;
+	}
 
 	explicit operator std::string () const {
 		std::string result;
+
+		unsigned short r = (backer & (255 << 24)) >> 24;
+		unsigned short g = (backer & (255 << 16)) >> 16;
+		unsigned short b = (backer & (255 << 8)) >> 8;
+		unsigned short a = (backer & (255 << 0)) >> 0;
+
 		for (unsigned short rgba : {r, g, b, a}) {
 			std::string channel = std::to_string(rgba);
 			const int minLen = 3;
@@ -26,7 +34,12 @@ public:
 	std::string getBits() const {
 		std::string result;
 
-		for (short rgba : {r, g, b, a}) {
+		unsigned short r = (backer & (255 << 24)) >> 24;
+		unsigned short g = (backer & (255 << 16)) >> 16;
+		unsigned short b = (backer & (255 << 8)) >> 8;
+		unsigned short a = (backer & (255 << 0)) >> 0;
+
+		for (unsigned short rgba : {r, g, b, a}) {
 			const int len = 8;
 			std::string channel = "";
 			for (int i = 0; i < len; ++i) {

--- a/PixelBits/Pixel64.h
+++ b/PixelBits/Pixel64.h
@@ -11,6 +11,8 @@ public:
 
 	Pixel64(unsigned int bits) {
 		// assume that backer is an int32_t
+		// flush out the bigger bits
+		bits = (bits << 32) >> 32;
 		backer = bits;
 	}
 

--- a/PixelBits/Pixel64.h
+++ b/PixelBits/Pixel64.h
@@ -9,11 +9,34 @@ struct Pixel64
 public:
 	unsigned int backer;
 
+	/// Construct a Pixel64 from user-specified int of format [[32 unused bits...], [8x r], [8x g], [8x b], [8x a]]
 	Pixel64(unsigned int bits) {
 		// assume that backer is an int32_t
 		// flush out the bigger bits
 		bits = (bits << 32) >> 32;
 		backer = bits;
+	}
+
+	void setChannel(int channel, unsigned short value) {
+		// this will be our new backer
+		unsigned int fValue = 0x00000000;
+
+		int maxi = 8 * (channel + 1);
+		int mini = 8 * (channel + 0);
+		for (int i = 0; i < 64; ++i) {
+			// check if bit in mini - maxi span. if so, get bit from value. else get bit from backer
+			int b = (backer & (1 << i));
+			if (mini <= i && i < maxi) {
+				// get ith bit of value
+				b = value & (1 << (i % 8));
+				// move into position to be logically OR'd with the unsigned int
+				b = b << (i - i % 8);
+			}
+			fValue = fValue | b;
+		}
+
+		// move bits
+		backer = fValue;
 	}
 
 	/// Given a query to a channel 0,1,2,3: get 0-255 / 8-bit data for that channel

--- a/PixelBits/Pixel64.h
+++ b/PixelBits/Pixel64.h
@@ -16,15 +16,21 @@ public:
 		backer = bits;
 	}
 
+	/// Given a query to a channel 0,1,2,3: get 0-255 / 8-bit data for that channel
+	unsigned short getChannel(int channel) const {
+		// channel = 0,1,2,3. shift by 0/8/16/24 bits
+		return (backer & (255 << (8 * channel))) >> (8 * channel);
+	}
+
+	unsigned short getR() const { return getChannel(0); }
+	unsigned short getG() const { return getChannel(1); }
+	unsigned short getB() const { return getChannel(2); }
+	unsigned short getA() const { return getChannel(3); }
+
 	explicit operator std::string () const {
 		std::string result;
 
-		unsigned short r = (backer & (255 << 24)) >> 24;
-		unsigned short g = (backer & (255 << 16)) >> 16;
-		unsigned short b = (backer & (255 << 8)) >> 8;
-		unsigned short a = (backer & (255 << 0)) >> 0;
-
-		for (unsigned short rgba : {r, g, b, a}) {
+		for (unsigned short rgba : {getR(), getG(), getB(), getA()}) {
 			std::string channel = std::to_string(rgba);
 			const int minLen = 3;
 			while (channel.size() < minLen) channel = "0" + channel;
@@ -36,12 +42,7 @@ public:
 	std::string getBits() const {
 		std::string result;
 
-		unsigned short r = (backer & (255 << 24)) >> 24;
-		unsigned short g = (backer & (255 << 16)) >> 16;
-		unsigned short b = (backer & (255 << 8)) >> 8;
-		unsigned short a = (backer & (255 << 0)) >> 0;
-
-		for (unsigned short rgba : {r, g, b, a}) {
+		for (unsigned short rgba : {getR(), getG(), getB(), getA()}) {
 			const int len = 8;
 			std::string channel = "";
 			for (int i = 0; i < len; ++i) {

--- a/PixelBits/PixelBits.cpp
+++ b/PixelBits/PixelBits.cpp
@@ -6,7 +6,7 @@
 #include "Pixel64.h"
 
 // debug utility
-std::string toBits(int value) {
+std::string toBits(unsigned int value) {
 	std::string result;
 	const int bitCount = 64;
 	for (int i = 0; i < bitCount; ++i) {
@@ -21,6 +21,10 @@ int main()
 	Pixel64 mpixel0(0);
 	Pixel64 mpixel1(3503345872); // 11010000 x 4
 	Pixel64 mpixel2(UINT_MAX);
+
+	// set channel 'r' to 255
+	mpixel1.setChannel(2, 255);
+	mpixel1.setChannel(3, 0);
 
 	for (Pixel64 mpixel : {mpixel0, mpixel1, mpixel2}) {
 		std::cout << "mpixel value is " << (std::string) mpixel << "with bits " << mpixel.getBits() << "\n";

--- a/PixelBits/PixelBits.cpp
+++ b/PixelBits/PixelBits.cpp
@@ -20,21 +20,11 @@ int main()
 {
 	Pixel64 mpixel0(0);
 	Pixel64 mpixel1(3503345872); // 11010000 x 4
-	Pixel64 mpixel2(INT_MAX);
+	Pixel64 mpixel2(UINT_MAX);
 
 	for (Pixel64 mpixel : {mpixel0, mpixel1, mpixel2}) {
 		std::cout << "mpixel value is " << (std::string) mpixel << "with bits " << mpixel.getBits() << "\n";
 	}
-
-	// 32 + 128 + 512 + 8192 = 8864
-	unsigned int code1 = (32 << 0) | (32 << 2) | (32 << 4) | (32 << 8);
-	unsigned int code2 = (32 << 0) + (32 << 2) + (32 << 4) + (32 << 8);
-	std::cout << "code1 result is " << code1 << ". code2 result is " << code2 << "\n";
-
-    std::cout << "Hello World!\n";
-
-	unsigned int value = 3503345872;
-	std::cout << "value " << value << " becomes " << toBits(value) << "\n";
 
 	int code;
 	std::cin >> code;

--- a/PixelBits/PixelBits.cpp
+++ b/PixelBits/PixelBits.cpp
@@ -5,11 +5,22 @@
 #include <iostream>
 #include "Pixel64.h"
 
+// debug utility
+std::string toBits(int value) {
+	std::string result;
+	const int bitCount = 64;
+	for (int i = 0; i < bitCount; ++i) {
+		result = std::to_string(value & 1) + result;
+		value = value >> 1;
+	}
+	return result;
+}
+
 int main()
 {
-	Pixel64 mpixel0{ 0, 0, 0, 0 };
-	Pixel64 mpixel1 = { 32,32,32,32 };
-	Pixel64 mpixel2{ 255, 255, 255, 255 };
+	Pixel64 mpixel0(0);
+	Pixel64 mpixel1(3503345872); // 11010000 x 4
+	Pixel64 mpixel2(INT_MAX);
 
 	for (Pixel64 mpixel : {mpixel0, mpixel1, mpixel2}) {
 		std::cout << "mpixel value is " << (std::string) mpixel << "with bits " << mpixel.getBits() << "\n";
@@ -21,6 +32,9 @@ int main()
 	std::cout << "code1 result is " << code1 << ". code2 result is " << code2 << "\n";
 
     std::cout << "Hello World!\n";
+
+	unsigned int value = 3503345872;
+	std::cout << "value " << value << " becomes " << toBits(value) << "\n";
 
 	int code;
 	std::cin >> code;


### PR DESCRIPTION
Converted Pixel64 from using unsigned short int[4] to instead using an int (with 64 bits). The layout in this int is 

[[32 unused bits...], [8 bits for r], [8 bits for g], [8 bits for b], [8 bits for a]].